### PR TITLE
FE#23/Create profile settings skeleton

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -20,7 +20,7 @@ function App(): JSX.Element {
               <Switch>
                 <Route exact path="/login" component={Login} />
                 <Route exact path="/signup" component={Signup} />
-                <Route exact path="/profile/:menuitem" component={ProfileSettings} />
+                <Route exact path="/profile/:options" component={ProfileSettings} />
                 <Route exact path="/dashboard">
                   <Dashboard />
                 </Route>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -20,7 +20,7 @@ function App(): JSX.Element {
               <Switch>
                 <Route exact path="/login" component={Login} />
                 <Route exact path="/signup" component={Signup} />
-                <Route exact path="/profile/:options" component={ProfileSettings} />
+                <Route path="/profile/options" component={ProfileSettings} />
                 <Route exact path="/dashboard">
                   <Dashboard />
                 </Route>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,8 +7,8 @@ import Dashboard from './pages/Dashboard/Dashboard';
 import { AuthProvider } from './context/useAuthContext';
 import { SocketProvider } from './context/useSocketContext';
 import { SnackBarProvider } from './context/useSnackbarContext';
-
 import './App.css';
+import ProfileSettings from './pages/ProfileSettings/ProfileSettings';
 
 function App(): JSX.Element {
   return (
@@ -20,6 +20,7 @@ function App(): JSX.Element {
               <Switch>
                 <Route exact path="/login" component={Login} />
                 <Route exact path="/signup" component={Signup} />
+                <Route exact path="/profile/:menuitem" component={ProfileSettings} />
                 <Route exact path="/dashboard">
                   <Dashboard />
                 </Route>

--- a/client/src/components/ProfileSettings/Availability/Availability.tsx
+++ b/client/src/components/ProfileSettings/Availability/Availability.tsx
@@ -3,3 +3,7 @@ import { Typography } from '@material-ui/core';
 export default function Availability(): JSX.Element {
   return <Typography>Availability</Typography>;
 }
+
+// TODO
+// This is a temporary component that renders itself to show that routes are working
+// Update this component to replicate the necessary UI for the availability of users

--- a/client/src/components/ProfileSettings/Availability/Availability.tsx
+++ b/client/src/components/ProfileSettings/Availability/Availability.tsx
@@ -1,0 +1,5 @@
+import { Typography } from '@material-ui/core';
+
+export default function Availability(): JSX.Element {
+  return <Typography>Availability</Typography>;
+}

--- a/client/src/components/ProfileSettings/Availability/useStyles.ts
+++ b/client/src/components/ProfileSettings/Availability/useStyles.ts
@@ -1,0 +1,5 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(() => ({}));
+
+export default useStyles;

--- a/client/src/components/ProfileSettings/Availability/useStyles.ts
+++ b/client/src/components/ProfileSettings/Availability/useStyles.ts
@@ -3,3 +3,6 @@ import { makeStyles } from '@material-ui/core/styles';
 const useStyles = makeStyles(() => ({}));
 
 export default useStyles;
+
+// TODO
+// Update this to add necessary styling for its component.

--- a/client/src/components/ProfileSettings/EditProfile/EditProfile.tsx
+++ b/client/src/components/ProfileSettings/EditProfile/EditProfile.tsx
@@ -1,5 +1,5 @@
-import { Grid } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
 
 export default function EditProfile(): JSX.Element {
-  return <Grid>Edit Profile</Grid>;
+  return <Typography>Edit Profile</Typography>;
 }

--- a/client/src/components/ProfileSettings/EditProfile/EditProfile.tsx
+++ b/client/src/components/ProfileSettings/EditProfile/EditProfile.tsx
@@ -3,3 +3,7 @@ import { Typography } from '@material-ui/core';
 export default function EditProfile(): JSX.Element {
   return <Typography>Edit Profile</Typography>;
 }
+
+// TODO
+// This is a temporary component that renders itself to show that routes are working
+// Update this component to replicate the necessary UI for the availability of users

--- a/client/src/components/ProfileSettings/EditProfile/EditProfile.tsx
+++ b/client/src/components/ProfileSettings/EditProfile/EditProfile.tsx
@@ -1,0 +1,5 @@
+import { Grid } from '@material-ui/core';
+
+export default function EditProfile(): JSX.Element {
+  return <Grid>Edit Profile</Grid>;
+}

--- a/client/src/components/ProfileSettings/EditProfile/useStyles.ts
+++ b/client/src/components/ProfileSettings/EditProfile/useStyles.ts
@@ -1,0 +1,5 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(() => ({}));
+
+export default useStyles;

--- a/client/src/components/ProfileSettings/EditProfile/useStyles.ts
+++ b/client/src/components/ProfileSettings/EditProfile/useStyles.ts
@@ -3,3 +3,6 @@ import { makeStyles } from '@material-ui/core/styles';
 const useStyles = makeStyles(() => ({}));
 
 export default useStyles;
+
+// TODO
+// Update this to add necessary styling for its component.

--- a/client/src/components/ProfileSettings/Options/Options.tsx
+++ b/client/src/components/ProfileSettings/Options/Options.tsx
@@ -1,0 +1,45 @@
+import Drawer from '@material-ui/core/Drawer';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
+import { Link } from 'react-router-dom';
+
+import useStyles from './useStyles';
+
+const Options = (): JSX.Element => {
+  const classes = useStyles();
+
+  return (
+    <Drawer
+      className={classes.drawer}
+      variant="permanent"
+      classes={{
+        paper: classes.drawerPaper,
+      }}
+      anchor="left"
+    >
+      <List>
+        <ListItem button disableGutters component={Link} to="/profile/options/edit-profile">
+          <ListItemText primary="Edit Profile" className={classes.listItem} />
+        </ListItem>
+        <ListItem button disableGutters component={Link} to="/profile/options/profile-photo">
+          <ListItemText primary="Profile Photo" className={classes.listItem} />
+        </ListItem>
+        <ListItem button disableGutters component={Link} to="/profile/options/availability">
+          <ListItemText primary="Availability" className={classes.listItem} />
+        </ListItem>
+        <ListItem button disableGutters component={Link} to="/profile/options/payment">
+          <ListItemText primary="Payment" className={classes.listItem} />
+        </ListItem>
+        <ListItem button disableGutters component={Link} to="/profile/options/security">
+          <ListItemText primary="Security" className={classes.listItem} />
+        </ListItem>
+        <ListItem button disableGutters component={Link} to="/profile/options/settings">
+          <ListItemText primary="Settings" className={classes.listItem} />
+        </ListItem>
+      </List>
+    </Drawer>
+  );
+};
+
+export default Options;

--- a/client/src/components/ProfileSettings/Options/useStyles.ts
+++ b/client/src/components/ProfileSettings/Options/useStyles.ts
@@ -1,0 +1,30 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const drawerWidth = '25%';
+
+const useStyles = makeStyles(() => ({
+  root: {
+    display: 'flex',
+    backgroundColor: 'none',
+  },
+  gridContainer: {
+    margin: '6% 15% 0% 15%',
+    height: '80vh',
+  },
+  drawer: {
+    width: drawerWidth,
+    flexShrink: 0,
+    border: '0',
+  },
+  drawerPaper: {
+    width: drawerWidth,
+    backgroundColor: '#fafafa',
+    border: '0',
+    top: '9%',
+  },
+  listItem: {
+    marginLeft: '30%',
+  },
+}));
+
+export default useStyles;

--- a/client/src/components/ProfileSettings/Payment/Payment.tsx
+++ b/client/src/components/ProfileSettings/Payment/Payment.tsx
@@ -1,0 +1,5 @@
+import { Grid } from '@material-ui/core';
+
+export default function Payment(): JSX.Element {
+  return <Grid>Payment</Grid>;
+}

--- a/client/src/components/ProfileSettings/Payment/Payment.tsx
+++ b/client/src/components/ProfileSettings/Payment/Payment.tsx
@@ -1,5 +1,5 @@
-import { Grid } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
 
 export default function Payment(): JSX.Element {
-  return <Grid>Payment</Grid>;
+  return <Typography>Payment</Typography>;
 }

--- a/client/src/components/ProfileSettings/Payment/Payment.tsx
+++ b/client/src/components/ProfileSettings/Payment/Payment.tsx
@@ -3,3 +3,7 @@ import { Typography } from '@material-ui/core';
 export default function Payment(): JSX.Element {
   return <Typography>Payment</Typography>;
 }
+
+// TODO
+// This is a temporary component that renders itself to show that routes are working
+// Update this component to replicate the necessary UI for the availability of users

--- a/client/src/components/ProfileSettings/Payment/useStyles.ts
+++ b/client/src/components/ProfileSettings/Payment/useStyles.ts
@@ -1,0 +1,5 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(() => ({}));
+
+export default useStyles;

--- a/client/src/components/ProfileSettings/Payment/useStyles.ts
+++ b/client/src/components/ProfileSettings/Payment/useStyles.ts
@@ -3,3 +3,6 @@ import { makeStyles } from '@material-ui/core/styles';
 const useStyles = makeStyles(() => ({}));
 
 export default useStyles;
+
+// TODO
+// Update this to add necessary styling for its component.

--- a/client/src/components/ProfileSettings/ProfilePhoto/ProfilePhoto.tsx
+++ b/client/src/components/ProfileSettings/ProfilePhoto/ProfilePhoto.tsx
@@ -1,0 +1,5 @@
+import { Grid } from '@material-ui/core';
+
+export default function ProfilePhoto(): JSX.Element {
+  return <Grid>Profile Photo</Grid>;
+}

--- a/client/src/components/ProfileSettings/ProfilePhoto/ProfilePhoto.tsx
+++ b/client/src/components/ProfileSettings/ProfilePhoto/ProfilePhoto.tsx
@@ -1,5 +1,5 @@
-import { Grid } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
 
 export default function ProfilePhoto(): JSX.Element {
-  return <Grid>Profile Photo</Grid>;
+  return <Typography>Profile Photo</Typography>;
 }

--- a/client/src/components/ProfileSettings/ProfilePhoto/ProfilePhoto.tsx
+++ b/client/src/components/ProfileSettings/ProfilePhoto/ProfilePhoto.tsx
@@ -3,3 +3,7 @@ import { Typography } from '@material-ui/core';
 export default function ProfilePhoto(): JSX.Element {
   return <Typography>Profile Photo</Typography>;
 }
+
+// TODO
+// This is a temporary component that renders itself to show that routes are working
+// Update this component to replicate the necessary UI for the availability of users

--- a/client/src/components/ProfileSettings/ProfilePhoto/useStyles.ts
+++ b/client/src/components/ProfileSettings/ProfilePhoto/useStyles.ts
@@ -1,0 +1,5 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(() => ({}));
+
+export default useStyles;

--- a/client/src/components/ProfileSettings/ProfilePhoto/useStyles.ts
+++ b/client/src/components/ProfileSettings/ProfilePhoto/useStyles.ts
@@ -3,3 +3,6 @@ import { makeStyles } from '@material-ui/core/styles';
 const useStyles = makeStyles(() => ({}));
 
 export default useStyles;
+
+// TODO
+// Update this to add necessary styling for its component.

--- a/client/src/components/ProfileSettings/Security/Security.tsx
+++ b/client/src/components/ProfileSettings/Security/Security.tsx
@@ -3,3 +3,7 @@ import { Typography } from '@material-ui/core';
 export default function Security(): JSX.Element {
   return <Typography>Security</Typography>;
 }
+
+// TODO
+// This is a temporary component that renders itself to show that routes are working
+// Update this component to replicate the necessary UI for the availability of users

--- a/client/src/components/ProfileSettings/Security/Security.tsx
+++ b/client/src/components/ProfileSettings/Security/Security.tsx
@@ -1,5 +1,5 @@
-import { Grid } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
 
 export default function Security(): JSX.Element {
-  return <Grid>Security</Grid>;
+  return <Typography>Security</Typography>;
 }

--- a/client/src/components/ProfileSettings/Security/Security.tsx
+++ b/client/src/components/ProfileSettings/Security/Security.tsx
@@ -1,0 +1,5 @@
+import { Grid } from '@material-ui/core';
+
+export default function Security(): JSX.Element {
+  return <Grid>Security</Grid>;
+}

--- a/client/src/components/ProfileSettings/Security/useStyles.ts
+++ b/client/src/components/ProfileSettings/Security/useStyles.ts
@@ -1,0 +1,5 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(() => ({}));
+
+export default useStyles;

--- a/client/src/components/ProfileSettings/Security/useStyles.ts
+++ b/client/src/components/ProfileSettings/Security/useStyles.ts
@@ -3,3 +3,6 @@ import { makeStyles } from '@material-ui/core/styles';
 const useStyles = makeStyles(() => ({}));
 
 export default useStyles;
+
+// TODO
+// Update this to add necessary styling for its component.

--- a/client/src/components/ProfileSettings/Settings/Settings.tsx
+++ b/client/src/components/ProfileSettings/Settings/Settings.tsx
@@ -1,5 +1,5 @@
-import { Grid } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
 
 export default function Settings(): JSX.Element {
-  return <Grid>Settings</Grid>;
+  return <Typography>Settings</Typography>;
 }

--- a/client/src/components/ProfileSettings/Settings/Settings.tsx
+++ b/client/src/components/ProfileSettings/Settings/Settings.tsx
@@ -3,3 +3,7 @@ import { Typography } from '@material-ui/core';
 export default function Settings(): JSX.Element {
   return <Typography>Settings</Typography>;
 }
+
+// TODO
+// This is a temporary component that renders itself to show that routes are working
+// Update this component to replicate the necessary UI for the availability of users

--- a/client/src/components/ProfileSettings/Settings/Settings.tsx
+++ b/client/src/components/ProfileSettings/Settings/Settings.tsx
@@ -1,0 +1,5 @@
+import { Grid } from '@material-ui/core';
+
+export default function Settings(): JSX.Element {
+  return <Grid>Settings</Grid>;
+}

--- a/client/src/components/ProfileSettings/Settings/useStyles.ts
+++ b/client/src/components/ProfileSettings/Settings/useStyles.ts
@@ -1,0 +1,5 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(() => ({}));
+
+export default useStyles;

--- a/client/src/components/ProfileSettings/Settings/useStyles.ts
+++ b/client/src/components/ProfileSettings/Settings/useStyles.ts
@@ -3,3 +3,6 @@ import { makeStyles } from '@material-ui/core/styles';
 const useStyles = makeStyles(() => ({}));
 
 export default useStyles;
+
+// TODO
+// Update this to add necessary styling for its component.

--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -26,9 +26,13 @@ export default function Dashboard(): JSX.Element {
     // loading for a split seconds until history.push works
     return <CircularProgress />;
   }
+  // TODO
+  // This temporary button is a placeholder and will be removed eventually.
+  // It's purpose is for now is to render the page for the user profile.
   const handleTemporaryButton = () => {
-    history.push('/profile/menuitems');
+    history.push('/profile/options');
   };
+
   return (
     <Grid container component="main" className={`${classes.root} ${classes.dashboard}`}>
       <CssBaseline />

--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -26,11 +26,14 @@ export default function Dashboard(): JSX.Element {
     // loading for a split seconds until history.push works
     return <CircularProgress />;
   }
-
+  const handleTemporaryButton = () => {
+    history.push('/profile/menuitems');
+  };
   return (
     <Grid container component="main" className={`${classes.root} ${classes.dashboard}`}>
       <CssBaseline />
       <Grid item className={classes.drawerWrapper}>
+        {<button onClick={handleTemporaryButton}>Options</button>}
         <ChatSideBanner loggedInUser={loggedInUser} />
       </Grid>
     </Grid>

--- a/client/src/pages/ProfileSettings/ProfileSettings.tsx
+++ b/client/src/pages/ProfileSettings/ProfileSettings.tsx
@@ -1,19 +1,20 @@
 import { Container, Grid, Link } from '@material-ui/core';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { useState } from 'react';
+import Availability from './../../components/ProfileSettings/Availability/Availability';
 import EditProfile from './../../components/ProfileSettings/EditProfile/EditProfile';
 import Payment from './../../components/ProfileSettings/Payment/Payment';
 import ProfilePhoto from './../../components/ProfileSettings/ProfilePhoto/ProfilePhoto';
-import Settings from './../../components/ProfileSettings/Settings/Settings';
 import Security from './../../components/ProfileSettings/Security/Security';
+import Settings from './../../components/ProfileSettings/Settings/Settings';
 import useStyles from './useStyles';
 
 export default function ProfileSettings(props: any): JSX.Element {
-  const MENU_LIST = ['Edit Profile', 'Profile Photo', 'Availability', 'Payment', 'Security', 'Settings'];
+  const Options = ['Edit Profile', 'Profile Photo', 'Availability', 'Payment', 'Security', 'Settings'];
 
   const classes = useStyles();
 
-  const [currentSection, setCurrentSection] = useState(props.match.params.menuitem);
+  const [currentSection, setCurrentSection] = useState(props.match.params.options);
 
   const handleClick = (section: string) => {
     setCurrentSection(section);
@@ -23,11 +24,13 @@ export default function ProfileSettings(props: any): JSX.Element {
   return (
     <Grid container className={`${classes.root}`}>
       <CssBaseline />
-      <Grid className={`${classes.menuItems}`}>
-        {MENU_LIST.map((item) => (
+      <Grid className={`${classes.optionItems}`}>
+        {Options.map((item) => (
           <Link
             onClick={() => handleClick(item.replace(/\s/g, '').toLowerCase())}
-            className={`${classes.menuItem} ${currentSection === item.replace(/\s/g, '') && classes.selectedMenuItem}`}
+            className={`${classes.optionItem} ${
+              currentSection === item.replace(/\s/g, '').toLowerCase() && classes.selectedOptionItem
+            }`}
             underline="none"
             key={item}
           >
@@ -38,6 +41,7 @@ export default function ProfileSettings(props: any): JSX.Element {
       <Container maxWidth="sm" className={classes.menuContainer}>
         {currentSection === 'editprofile' && <EditProfile />}
         {currentSection === 'profilephoto' && <ProfilePhoto />}
+        {currentSection === 'availability' && <Availability />}
         {currentSection === 'payment' && <Payment />}
         {currentSection === 'security' && <Security />}
         {currentSection === 'settings' && <Settings />}

--- a/client/src/pages/ProfileSettings/ProfileSettings.tsx
+++ b/client/src/pages/ProfileSettings/ProfileSettings.tsx
@@ -17,7 +17,6 @@ export default function ProfileSettings(): JSX.Element {
   const location = useLocation();
 
   const handleRoute = (path: string) => {
-    console.log(path);
     switch (path) {
       case '/profile/options/edit-profile':
         return <EditProfile />;

--- a/client/src/pages/ProfileSettings/ProfileSettings.tsx
+++ b/client/src/pages/ProfileSettings/ProfileSettings.tsx
@@ -1,51 +1,58 @@
-import { Container, Grid, Link } from '@material-ui/core';
+import { Grid } from '@material-ui/core';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import { useState } from 'react';
+import Paper from '@material-ui/core/Paper';
+import { useLocation } from 'react-router-dom';
 import Availability from './../../components/ProfileSettings/Availability/Availability';
 import EditProfile from './../../components/ProfileSettings/EditProfile/EditProfile';
+import Options from './../../components/ProfileSettings/Options/Options';
 import Payment from './../../components/ProfileSettings/Payment/Payment';
 import ProfilePhoto from './../../components/ProfileSettings/ProfilePhoto/ProfilePhoto';
 import Security from './../../components/ProfileSettings/Security/Security';
 import Settings from './../../components/ProfileSettings/Settings/Settings';
 import useStyles from './useStyles';
 
-export default function ProfileSettings(props: any): JSX.Element {
-  const Options = ['Edit Profile', 'Profile Photo', 'Availability', 'Payment', 'Security', 'Settings'];
-
+export default function ProfileSettings(): JSX.Element {
   const classes = useStyles();
 
-  const [currentSection, setCurrentSection] = useState(props.match.params.options);
+  const location = useLocation();
 
-  const handleClick = (section: string) => {
-    setCurrentSection(section);
-    props.history.push(`/profile/${section}`);
+  const handleRoute = (path: string) => {
+    console.log(path);
+    switch (path) {
+      case '/profile/options/edit-profile':
+        return <EditProfile />;
+
+      case '/profile/options/profile-photo':
+        return <ProfilePhoto />;
+
+      case '/profile/options/availability':
+        return <Availability />;
+
+      case '/profile/options/payment':
+        return <Payment />;
+
+      case '/profile/options/security':
+        return <Security />;
+
+      case '/profile/options/settings':
+        return <Settings />;
+
+      default:
+        return <EditProfile />;
+    }
   };
 
   return (
-    <Grid container className={`${classes.root}`}>
+    <Grid container>
       <CssBaseline />
-      <Grid className={`${classes.optionItems}`}>
-        {Options.map((item) => (
-          <Link
-            onClick={() => handleClick(item.replace(/\s/g, '').toLowerCase())}
-            className={`${classes.optionItem} ${
-              currentSection === item.replace(/\s/g, '').toLowerCase() && classes.selectedOptionItem
-            }`}
-            underline="none"
-            key={item}
-          >
-            {item}
-          </Link>
-        ))}
+      <Grid item xs={2}>
+        <Options />
       </Grid>
-      <Container maxWidth="sm" className={classes.menuContainer}>
-        {currentSection === 'editprofile' && <EditProfile />}
-        {currentSection === 'profilephoto' && <ProfilePhoto />}
-        {currentSection === 'availability' && <Availability />}
-        {currentSection === 'payment' && <Payment />}
-        {currentSection === 'security' && <Security />}
-        {currentSection === 'settings' && <Settings />}
-      </Container>
+      <Grid item xs={10} className={classes.root}>
+        <Paper elevation={3} className={classes.gridContainer}>
+          {handleRoute(location.pathname)}
+        </Paper>
+      </Grid>
     </Grid>
   );
 }

--- a/client/src/pages/ProfileSettings/ProfileSettings.tsx
+++ b/client/src/pages/ProfileSettings/ProfileSettings.tsx
@@ -1,0 +1,47 @@
+import { Container, Grid, Link } from '@material-ui/core';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import { useState } from 'react';
+import EditProfile from './../../components/ProfileSettings/EditProfile/EditProfile';
+import Payment from './../../components/ProfileSettings/Payment/Payment';
+import ProfilePhoto from './../../components/ProfileSettings/ProfilePhoto/ProfilePhoto';
+import Settings from './../../components/ProfileSettings/Settings/Settings';
+import Security from './../../components/ProfileSettings/Security/Security';
+import useStyles from './useStyles';
+
+export default function ProfileSettings(props: any): JSX.Element {
+  const MENU_LIST = ['Edit Profile', 'Profile Photo', 'Availability', 'Payment', 'Security', 'Settings'];
+
+  const classes = useStyles();
+
+  const [currentSection, setCurrentSection] = useState(props.match.params.menuitem);
+
+  const handleClick = (section: string) => {
+    setCurrentSection(section);
+    props.history.push(`/profile/${section}`);
+  };
+
+  return (
+    <Grid container className={`${classes.root}`}>
+      <CssBaseline />
+      <Grid className={`${classes.menuItems}`}>
+        {MENU_LIST.map((item) => (
+          <Link
+            onClick={() => handleClick(item.replace(/\s/g, '').toLowerCase())}
+            className={`${classes.menuItem} ${currentSection === item.replace(/\s/g, '') && classes.selectedMenuItem}`}
+            underline="none"
+            key={item}
+          >
+            {item}
+          </Link>
+        ))}
+      </Grid>
+      <Container maxWidth="sm" className={classes.menuContainer}>
+        {currentSection === 'editprofile' && <EditProfile />}
+        {currentSection === 'profilephoto' && <ProfilePhoto />}
+        {currentSection === 'payment' && <Payment />}
+        {currentSection === 'security' && <Security />}
+        {currentSection === 'settings' && <Settings />}
+      </Container>
+    </Grid>
+  );
+}

--- a/client/src/pages/ProfileSettings/useStyles.ts
+++ b/client/src/pages/ProfileSettings/useStyles.ts
@@ -2,33 +2,40 @@ import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles(() => ({
   root: {
-    backgroundColor: '#FAFAFB',
-    position: 'absolute',
+    backgroundColor: '#FAFAFA',
+    position: 'relative',
     top: 0,
     left: 0,
-    width: '100%',
     height: '100%',
-    marginTop: '50px',
+    marginTop: '55px',
   },
-  menuItem: {
+  optionItem: {
     fontSize: '1.1rem',
-    margin: '10px 40px',
-    color: '#8D8D8D',
+    margin: '12px 150px',
+    color: '#9d9d9d',
+    fontWeight: 600,
     hover: 'none',
-    fontWeight: 800,
+    cursor: 'pointer',
+    width: 'fit-content',
   },
-  selectedMenuItem: {
-    color: '#000000',
+  selectedOptionItem: {
+    color: '#131313',
   },
-  menuItems: {
+  optionItems: {
+    marginTop: '18px',
     display: 'flex',
     flexDirection: 'column',
-    cursor: 'pointer',
+    width: '30%',
   },
   menuContainer: {
-    boxShadow: '0px 0px 8px #CACACA',
+    position: 'relative',
+    boxShadow: '0px 0px 15px #CACACA',
     borderRadius: '5px',
-    height: '80vh',
+    height: '85vh',
+    margin: 0,
+    padding: 0,
+    display: 'flex',
+    justifyContent: 'center',
   },
 }));
 

--- a/client/src/pages/ProfileSettings/useStyles.ts
+++ b/client/src/pages/ProfileSettings/useStyles.ts
@@ -1,0 +1,35 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(() => ({
+  root: {
+    backgroundColor: '#FAFAFB',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    marginTop: '50px',
+  },
+  menuItem: {
+    fontSize: '1.1rem',
+    margin: '10px 40px',
+    color: '#8D8D8D',
+    hover: 'none',
+    fontWeight: 800,
+  },
+  selectedMenuItem: {
+    color: '#000000',
+  },
+  menuItems: {
+    display: 'flex',
+    flexDirection: 'column',
+    cursor: 'pointer',
+  },
+  menuContainer: {
+    boxShadow: '0px 0px 8px #CACACA',
+    borderRadius: '5px',
+    height: '80vh',
+  },
+}));
+
+export default useStyles;

--- a/client/src/pages/ProfileSettings/useStyles.ts
+++ b/client/src/pages/ProfileSettings/useStyles.ts
@@ -3,39 +3,12 @@ import { makeStyles } from '@material-ui/core/styles';
 const useStyles = makeStyles(() => ({
   root: {
     backgroundColor: '#FAFAFA',
-    position: 'relative',
-    top: 0,
-    left: 0,
-    height: '100%',
-    marginTop: '55px',
   },
-  optionItem: {
-    fontSize: '1.1rem',
-    margin: '12px 150px',
-    color: '#9d9d9d',
-    fontWeight: 600,
-    hover: 'none',
-    cursor: 'pointer',
-    width: 'fit-content',
-  },
-  selectedOptionItem: {
-    color: '#131313',
-  },
-  optionItems: {
-    marginTop: '18px',
-    display: 'flex',
-    flexDirection: 'column',
-    width: '30%',
-  },
-  menuContainer: {
-    position: 'relative',
-    boxShadow: '0px 0px 15px #CACACA',
-    borderRadius: '5px',
-    height: '85vh',
-    margin: 0,
-    padding: 0,
-    display: 'flex',
+  gridContainer: {
+    margin: '5% 15% 0% 11%',
+    padding: '3% 7% 3% 7%',
     justifyContent: 'center',
+    minHeight: '80vh',
   },
 }));
 

--- a/client/src/themes/theme.ts
+++ b/client/src/themes/theme.ts
@@ -8,6 +8,12 @@ export const theme = createMuiTheme({
       textTransform: 'none',
       fontWeight: 700,
     },
+    body1: {
+      fontFamily: '"Open Sans", "sans-serif", "Roboto"',
+      fontSize: 15,
+      color: '#9d9d9d',
+      fontWeight: 600,
+    },
   },
   palette: {
     primary: { main: '#3A8DFF' },


### PR DESCRIPTION
### What this PR does (required):
- Create profile settings skeleton
- Create a profile settings folder under components and pages
- Create a temporary button to render the profile settings skeleton
- Modify App.tsx to add a route for the profile settings component

### Screenshots / Videos (required):
- Temporary button to render profile settings skeleton:
![temporary-button](https://user-images.githubusercontent.com/62577683/129394501-b86e6626-e159-4ae3-8ff5-958b85220ca8.jpg)
- Profile settings skeleton while selecting edit profile:
![selecting-editprofile](https://user-images.githubusercontent.com/62577683/129394709-16933728-67d0-4a13-a8a7-3b5eb14968eb.jpg)
- Selecting profile photo:
![selecting-profilephoto](https://user-images.githubusercontent.com/62577683/129395506-fb294636-ff9d-4f6b-a635-800c5173f77d.jpg)
- Created folders under components and pages:
![createdfolders](https://user-images.githubusercontent.com/62577683/129394992-e7d06833-cd6e-4f3d-9dee-94b83af6fbe0.jpg)


### Any information needed to test this feature (required):
- Run the server: npm run dev
- Run the client: npm start
- Sign in using boolean,autocrats credentials
- Click temporary button
- Click any of the options: Edit Profile, Profile Photo, Availability, Payment, Security, Settings

### Any issues with the current functionality (optional):
N/A